### PR TITLE
Fix path comparison for canonicalization

### DIFF
--- a/yazi-core/src/mgr/watcher.rs
+++ b/yazi-core/src/mgr/watcher.rs
@@ -139,8 +139,9 @@ impl Watcher {
 					continue;
 				};
 
-				let u = &file.url;
-				let eq = (!file.is_link() && fs::canonicalize(u).await.is_ok_and(|p| p == ***u))
+                                let u = &file.url;
+                                let eq = (!file.is_link()
+                                        && fs::canonicalize(u).await.is_ok_and(|p| p == **u))
 					|| realname_unchecked(u, &mut cached).await.is_ok_and(|s| urn.as_urn() == s);
 
 				if !eq {


### PR DESCRIPTION
## Summary
- update path comparison in watcher to avoid triple deref

## Testing
- `cargo check -p yazi-core` *(fails: Could not connect to server)*