### PR TITLE
Improve build.sh zip handling

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Prerequisite: the 'zip' utility must be installed.
+
 export ARTIFACT_NAME="yazi-$1"
 export YAZI_GEN_COMPLETIONS=1
 
@@ -17,8 +19,25 @@ cp yazi-boot/completions/* "$ARTIFACT_NAME/completions"
 cp README.md LICENSE "$ARTIFACT_NAME"
 
 # Zip the artifact
-if ! command -v zip &> /dev/null
-then
-	sudo apt-get update && sudo apt-get install -yq zip
+# NOTE: The 'zip' command must be available. If it's missing, hint how to
+# install it using the detected package manager and exit with an error.
+if ! command -v zip >/dev/null 2>&1; then
+    echo "Error: 'zip' is required to create release archives." >&2
+    if command -v apt-get >/dev/null 2>&1; then
+        echo "Install it using: sudo apt-get install zip" >&2
+    elif command -v dnf >/dev/null 2>&1; then
+        echo "Install it using: sudo dnf install zip" >&2
+    elif command -v yum >/dev/null 2>&1; then
+        echo "Install it using: sudo yum install zip" >&2
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "Install it using: sudo pacman -S zip" >&2
+    elif command -v brew >/dev/null 2>&1; then
+        echo "Install it using: brew install zip" >&2
+    elif command -v zypper >/dev/null 2>&1; then
+        echo "Install it using: sudo zypper install zip" >&2
+    else
+        echo "Please install the 'zip' package using your system's package manager." >&2
+    fi
+    exit 1
 fi
 zip -r "$ARTIFACT_NAME.zip" "$ARTIFACT_NAME"


### PR DESCRIPTION
## Summary
- note that zip is a prerequisite
- give instructions for installing zip using a detected package manager
- exit with an error if zip is missing

## Testing
- `cargo fmt -- --check` *(fails: rustfmt not installed)*
- `cargo test --workspace --verbose` *(fails: network access required)*